### PR TITLE
Add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <img alt="python" src="https://img.shields.io/badge/license-%20%20GNU%20GPLv3%20-green?style=for-the-badge"></a>
 <img alt="python" src="https://img.shields.io/badge/python-3.11%20|%203.12%20|%203.13%20|%203.14-blue?style=for-the-badge"></a>
 <a href="https://github.com/astral-sh/ruff" rel="nofollow noreferrer noopener" target="_blank"><img alt="Linting: Ruff" src="https://img.shields.io/badge/Ruff-D7FF64?style=for-the-badge&label=Linting&logo=ruff&logoColor=black"></a>
+<a href="https://github.com/esalient/pysalient/actions/workflows/ci.yml"><img alt="CI Status" src="https://github.com/esalient/pysalient/actions/workflows/ci.yml/badge.svg" style="for-the-badge"></a>
 
 Python implementation of the SALIENT framework to 
 assist with clinical AI research and implementation.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <img alt="python" src="https://img.shields.io/badge/license-%20%20GNU%20GPLv3%20-green?style=for-the-badge"></a>
 <img alt="python" src="https://img.shields.io/badge/python-3.11%20|%203.12%20|%203.13%20|%203.14-blue?style=for-the-badge"></a>
 <a href="https://github.com/astral-sh/ruff" rel="nofollow noreferrer noopener" target="_blank"><img alt="Linting: Ruff" src="https://img.shields.io/badge/Ruff-D7FF64?style=for-the-badge&label=Linting&logo=ruff&logoColor=black"></a>
-<a href="https://github.com/esalient/pysalient/actions/workflows/ci.yml"><img alt="CI Status" src="https://github.com/esalient/pysalient/actions/workflows/ci.yml/badge.svg" style="for-the-badge"></a>
+<a href="https://github.com/esalient/pysalient/actions/workflows/ci.yml"><img alt="CI Status" src="https://img.shields.io/github/actions/workflow/status/esalient/pysalient/ci.yml?style=for-the-badge&label=CI"></a>
 
 Python implementation of the SALIENT framework to 
 assist with clinical AI research and implementation.


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI status badge to the README badge row, linking to the CI workflow for quick build health visibility.

## Test plan
- [ ] Verify the badge renders correctly on the GitHub README after merging.